### PR TITLE
add error handling on websocket open

### DIFF
--- a/hipercam/hcam/raw.py
+++ b/hipercam/hcam/raw.py
@@ -113,6 +113,9 @@ class Rhead:
         if server:
             # open socket connection to server
             self._ws = websocket.create_connection(URL + fname)
+            status = json.loads(self._ws.recv())['status']
+            if status == 'no such run':
+                raise HipercamError('Run not found: {}'.format(fname))
 
             # read the header from the server
             data = json.dumps(dict(action='get_hdr'))


### PR DESCRIPTION
the error messages when a user tries to access a non-existent run were pretty opaque, so I've added error handling to the web socket connection.

This requires the latest master of ```hcam-drivers```, pushed at 13:30 on Oct 5th 2017.